### PR TITLE
[book-store] Updates test runner so it is not DRY

### DIFF
--- a/exercises/book-store/uBookStoreTests.pas
+++ b/exercises/book-store/uBookStoreTests.pas
@@ -7,23 +7,53 @@ uses
 type
   [TestFixture]
   hpTests = class(TObject)
-  private
-    class function ConvertStrToIntArray(aString: string): TArray<Integer>; static;
   public
     [Test]
-    [TestCase('Test total basket price single book',                                     '1, 8.0')]
-//    [TestCase('Test total basket Price two of same book',                                '2|2, 16.0')]
-//    [TestCase('Test total basket price empty basket',                                    ', 0.0')]
-//    [TestCase('Test basket with two different books',                                    '1|2, 15.2')]
-//    [TestCase('Test basket with three different books',                                  '1|2|3, 21.6')]
-//    [TestCase('Test basket with four different books',                                   '1|2|3|4, 25.6')]
-//    [TestCase('Test basket with five different books',                                   '1|2|3|4|5, 30.0')]
-//    [TestCase('Test basket w/2 copies of books 1..3 and one copy of books 4 and 5',      '1|1|2|2|3|3|4|5, 51.20')]
-//    [TestCase('Test basket w/2 copies of books 1..4 and one copy of book 5',             '1|1|2|2|3|3|4|4|5, 55.60')]
-//    [TestCase('Test basket w/2 copies of each book',                                     '1|1|2|2|3|3|4|4|5|5, 60.00')]
-//    [TestCase('Test basket w/2 copies of each book plus one more copy of book 1',        '1|1|2|2|3|3|4|4|5|5|1, 68.00')]
-//    [TestCase('Test basket w/2 copies of each book plus one more copy of books 1 and 2', '1|1|2|2|3|3|4|4|5|5|1|2, 75.20')]
-    procedure SeveralBasketTestCases(const aBasket: string; const Expected: extended);
+    procedure A_basket_containing_only_a_single_book;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_containing_only_two_of_the_same_book;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure No_charge_to_carry_around_an_empty_basket;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_containing_only_two_different_books;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_with_three_different_books;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_with_four_different_books;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_with_five_different_books;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_containing_eight_books_consisting_of_a_pair_each_of_the_first_three_books_plus_one_copy_each_of_the_last_two_books;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_containing_nine_books_consisting_of_a_pair_each_of_the_first_four_books_plus_one_of_the_last_book;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_containing_ten_books_consisting_of_two_copies_of_each_book_in_the_series;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_containing_eleven_books_consisting_of_three_copies_of_the_first_book_plus_two_each_of_the_remaing_four_bookes_in_the_series;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure A_basket_containing_twelve_books_consisting_of_three_copies_of_the_first_two_books_plus_two_each_of_the_remaining_three_books_in_the_series;
   end;
 
 implementation
@@ -31,24 +61,215 @@ uses System.SysUtils, uBookStore;
 
 const MinDelta = 0.005; //cents
 
-class function hpTests.ConvertStrToIntArray(aString: string): TArray<Integer>;
-var splitStr: TArray<string>;
-    i: integer;
-begin
-  result := nil;
-  splitStr := aString.Split(['|']);
-  SetLength(result, length(splitStr));
-  for i := Low(splitStr) to High(splitStr) do
-    result[i] := splitStr[i].ToInteger;
-end;
-
-procedure hpTests.SeveralBasketTestCases(const aBasket: string; const Expected: extended);
+procedure hpTests.A_basket_containing_only_a_single_book;
 var Basket: TArray<integer>;
     fBasket: IBasket;
+    Expected: double;
 begin
-  Basket := ConvertStrToIntArray(aBasket);
+  SetLength(Basket, 1);
+  Basket[0] := 1;
+  Expected := 8.0;
+
   fBasket := NewBasket(Basket);
-  assert.AreEqual(Expected, FBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_containing_only_two_of_the_same_book;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 2);
+  Basket[0] := 2;
+  Basket[1] := 2;
+  Expected := 16.0;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.No_charge_to_carry_around_an_empty_basket;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 0);
+  Expected := 0.0;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_containing_only_two_different_books;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 2);
+  Basket[0] := 1;
+  Basket[1] := 2;
+  Expected := 15.2;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_with_three_different_books;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 3);
+  Basket[0] := 1;
+  Basket[1] := 2;
+  Basket[2] := 3;
+  Expected := 21.6;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_with_four_different_books;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 4);
+  Basket[0] := 1;
+  Basket[1] := 2;
+  Basket[2] := 3;
+  Basket[3] := 4;
+  Expected := 25.6;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_with_five_different_books;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 5);
+  Basket[0] := 1;
+  Basket[1] := 2;
+  Basket[2] := 3;
+  Basket[3] := 4;
+  Basket[4] := 5;
+  Expected := 30.0;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_containing_eight_books_consisting_of_a_pair_each_of_the_first_three_books_plus_one_copy_each_of_the_last_two_books;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 8);
+  Basket[0] := 1;
+  Basket[1] := 1;
+  Basket[2] := 2;
+  Basket[3] := 2;
+  Basket[4] := 3;
+  Basket[5] := 3;
+  Basket[6] := 4;
+  Basket[7] := 5;
+  Expected := 51.20;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_containing_nine_books_consisting_of_a_pair_each_of_the_first_four_books_plus_one_of_the_last_book;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 9);
+  Basket[0] := 1;
+  Basket[1] := 1;
+  Basket[2] := 2;
+  Basket[3] := 2;
+  Basket[4] := 3;
+  Basket[5] := 3;
+  Basket[6] := 4;
+  Basket[7] := 4;
+  Basket[8] := 5;
+  Expected := 55.60;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_containing_ten_books_consisting_of_two_copies_of_each_book_in_the_series;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 10);
+  Basket[0] := 1;
+  Basket[1] := 1;
+  Basket[2] := 2;
+  Basket[3] := 2;
+  Basket[4] := 3;
+  Basket[5] := 3;
+  Basket[6] := 4;
+  Basket[7] := 4;
+  Basket[8] := 5;
+  Basket[9] := 5;
+  Expected := 60.00;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_containing_eleven_books_consisting_of_three_copies_of_the_first_book_plus_two_each_of_the_remaing_four_bookes_in_the_series;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 11);
+  Basket[0] := 1;
+  Basket[1] := 1;
+  Basket[2] := 2;
+  Basket[3] := 2;
+  Basket[4] := 3;
+  Basket[5] := 3;
+  Basket[6] := 4;
+  Basket[7] := 4;
+  Basket[8] := 5;
+  Basket[9] := 5;
+  Basket[10] := 1;
+  Expected := 68.00;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
+end;
+
+procedure hpTests.A_basket_containing_twelve_books_consisting_of_three_copies_of_the_first_two_books_plus_two_each_of_the_remaining_three_books_in_the_series;
+var Basket: TArray<integer>;
+    fBasket: IBasket;
+    Expected: double;
+begin
+  SetLength(Basket, 12);
+  Basket[0] := 1;
+  Basket[1] := 1;
+  Basket[2] := 2;
+  Basket[3] := 2;
+  Basket[4] := 3;
+  Basket[5] := 3;
+  Basket[6] := 4;
+  Basket[7] := 4;
+  Basket[8] := 5;
+  Basket[9] := 5;
+  Basket[10] := 1;
+  Basket[11] := 2;
+  Expected := 75.20;
+
+  fBasket := NewBasket(Basket);
+  assert.AreEqual(Expected, fBasket.Total, MinDelta, format('Total should be %0.2f',[Expected]));
 end;
 
 initialization


### PR DESCRIPTION
Test runner is no longer DRY and very closely matces this exercises
canonicaldata.json. As an aside I think the canonicaldata.json is too
wordy on some the tests. Test 8 gives a hint towards the solution that
I don't like. I think "targetdata" makes the description of test 8 a
little redundant in my opinion.