### PR TITLE
Changes track description to Delphi Pascal

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "slug": "pascal",
-  "language": "Object Pascal",
+  "language": "Delphi Pascal",
   "repository": "https://github.com/exercism/xpascal",
   "active": false,
   "exercises": [


### PR DESCRIPTION
@kytrinyx agrees that the track should be renamed.   The xpascal repo will need to be renamed, guessing xdelphipascal will be the new name.