### PR TITLE
grains: adding exercise to track

### DIFF
--- a/config.json
+++ b/config.json
@@ -60,6 +60,14 @@
       ]
     },
     {
+	    "slug": "grains",
+	    "difficulty": 2,
+	    "topics": [
+	      "Integers",
+	      "Recursion"
+      ]
+    },
+    {
       "slug": "beer-song",
       "difficulty": 3,
       "topics": [

--- a/exercises/grains/GrainsTests.dpr
+++ b/exercises/grains/GrainsTests.dpr
@@ -1,0 +1,60 @@
+program GrainsTests;
+
+{$IFNDEF TESTINSIGHT}
+{$APPTYPE CONSOLE}
+{$ENDIF}{$STRONGLINKTYPES ON}
+uses
+  System.SysUtils,
+  {$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX,
+  {$ENDIF }
+  DUnitX.Loggers.Console,
+  DUnitX.Loggers.Xml.NUnit,
+  DUnitX.TestFramework,
+  uGrainsTests in 'uGrainsTests.pas',
+  uGrains in 'uGrains.pas';
+
+var
+  runner : ITestRunner;
+  results : IRunResults;
+  logger : ITestLogger;
+  nunitLogger : ITestLogger;
+begin
+{$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX.RunRegisteredTests;
+  exit;
+{$ENDIF}
+  try
+    //Check command line options, will exit if invalid
+    TDUnitX.CheckCommandLine;
+    //Create the test runner
+    runner := TDUnitX.CreateRunner;
+    //Tell the runner to use RTTI to find Fixtures
+    runner.UseRTTI := True;
+    //tell the runner how we will log things
+    //Log to the console window
+    logger := TDUnitXConsoleLogger.Create(true);
+    runner.AddLogger(logger);
+    //Generate an NUnit compatible XML File
+    nunitLogger := TDUnitXXMLNUnitFileLogger.Create(TDUnitX.Options.XMLOutputFile);
+    runner.AddLogger(nunitLogger);
+    runner.FailsOnNoAsserts := False; //When true, Assertions must be made during tests;
+
+    //Run tests
+    results := runner.Execute;
+    if not results.AllPassed then
+      System.ExitCode := EXIT_ERRORS;
+
+    {$IFNDEF CI}
+    //We don't want this happening when running under CI.
+    if TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause then
+    begin
+      System.Write('Done.. press <Enter> key to quit.');
+      System.Readln;
+    end;
+    {$ENDIF}
+  except
+    on E: Exception do
+      System.Writeln(E.ClassName, ': ', E.Message);
+  end;
+end.

--- a/exercises/grains/uGrainsExample.pas
+++ b/exercises/grains/uGrainsExample.pas
@@ -1,0 +1,33 @@
+unit uGrains;
+
+interface
+
+type
+  Grains = class
+    class function Square(aInteger: integer): UInt64; static;
+    class function Total: UInt64; static;
+  end;
+
+implementation
+uses System.SysUtils;
+
+class function Grains.Square(aInteger: integer): UInt64;
+begin
+  if (aInteger < 1) or (aInteger > 64) then
+    raise ERangeError.CreateFmt('Argument of %d is out of bounds.  Must be > 0 and < 65',[aInteger]);
+
+  if aInteger = 1 then
+    result := 1
+  else
+    result := 2 * Square(aInteger - 1);
+end;
+
+class function Grains.Total: UInt64;
+var i: integer;
+begin
+  result := 0;
+  for i := 1 to 64 do
+    result := result + Square(i);
+end;
+
+end.

--- a/exercises/grains/uGrainsTests.pas
+++ b/exercises/grains/uGrainsTests.pas
@@ -1,4 +1,4 @@
-unit uBookStoreTests;
+unit uGrainsTests;
 
 interface
 uses
@@ -9,7 +9,6 @@ type
   TgrainsTests = class(TObject)
   public
     [Test]
-    [Ignore('Comment this line to run this test')]
     procedure Test_square_1;
 
     [Test]
@@ -57,65 +56,94 @@ implementation
 uses System.SysUtils, uGrains;
 
 procedure TgrainsTests.Test_square_1;
+var expected: UInt64;
 begin
-  Assert.AreEqual(1, Grains.Square(1));
+  expected := 1;
+  Assert.AreEqual(expected, Grains.Square(1));
 end;
 
 procedure TgrainsTests.Test_square_2;
+var expected: UInt64;
 begin
-  Assert.AreEqual(2, Grains.Square(2));
+  expected := 2;
+  Assert.AreEqual(expected, Grains.Square(2));
 end;
 
 procedure TgrainsTests.Test_square_3;
+var expected: UInt64;
 begin
-  Assert.AreEqual(3, Grains.Square(3));
+  expected := 4;
+  Assert.AreEqual(expected, Grains.Square(3));
 end;
 
 procedure TgrainsTests.Test_square_4;
+var expected: UInt64;
 begin
-  Assert.AreEqual(8, Grains.Square(4));
+  expected := 8;
+  Assert.AreEqual(expected, Grains.Square(4));
 end;
 
 procedure TgrainsTests.Test_square_16;
+var expected: UInt64;
 begin
-  Assert.AreEqual(32768, Grains.Square(16));
+  expected := 32768;
+  Assert.AreEqual(expected, Grains.Square(16));
 end;
 
 procedure TgrainsTests.Test_square_32;
+var expected: UInt64;
 begin
-  Assert.AreEqual(2147483648, Grains.Square(32));
+  expected := 2147483648;
+  Assert.AreEqual(expected, Grains.Square(32));
 end;
 
 procedure TgrainsTests.Test_square_64;
+var expected: UInt64;
 begin
-  Assert.AreEqual(9223372036854775808, Grains.Square(64));
-end;
-
-procedure TgrainsTests.Test_total_grains;
-begin
-  Assert.AreEqual(18446744073709551615, Grains.Total);
+  expected := 9223372036854775808;
+  Assert.AreEqual(expected, Grains.Square(64));
 end;
 
 procedure TgrainsTests.Square_0_raises_an_exception;
+var MyProc: TTestLocalMethod;
 begin
+  MyProc := procedure
+            begin
+              Grains.Square(0);
+            end;
 
+  Assert.WillRaise(MyProc, ERangeError);
 end;
 
 procedure TgrainsTests.Negative_square_raises_an_exception;
+var MyProc: TTestLocalMethod;
 begin
+  MyProc := procedure
+            begin
+              Grains.Square(-1);
+            end;
 
+  Assert.WillRaise(MyProc, ERangeError);
 end;
 
 procedure TgrainsTests.Square_greater_than_64_raises_an_exception;
+var MyProc: TTestLocalMethod;
 begin
+  MyProc := procedure
+            begin
+              Grains.Square(65);
+            end;
 
+  Assert.WillRaise(MyProc, ERangeError);
 end;
 
 procedure TgrainsTests.Test_total_grains;
+var expected: UInt64;
 begin
-  Assert.AreEqual(18446744073709551615, Grains.Total);
+  expected := 18446744073709551615;
+  Assert.AreEqual(expected, Grains.Total);
 end;
 
 initialization
-  TDUnitX.RegisterTestFixture(hpTests);
+  TDUnitX.RegisterTestFixture(TgrainsTests);
 end.

--- a/exercises/grains/uGrainsTests.pas
+++ b/exercises/grains/uGrainsTests.pas
@@ -1,0 +1,121 @@
+unit uBookStoreTests;
+
+interface
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  TgrainsTests = class(TObject)
+  public
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Test_square_1;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Test_square_2;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Test_square_3;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Test_square_4;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Test_square_16;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Test_square_32;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Test_square_64;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Square_0_raises_an_exception;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Negative_square_raises_an_exception;
+
+    [Test]
+    [Ignore('Comment this line to run the test')]
+    procedure Square_greater_than_64_raises_an_exception;
+
+    [Test]
+    [Ignore('Comment this line to run this test')]
+    procedure Test_total_grains;
+  end;
+
+implementation
+uses System.SysUtils, uGrains;
+
+procedure TgrainsTests.Test_square_1;
+begin
+  Assert.AreEqual(1, Grains.Square(1));
+end;
+
+procedure TgrainsTests.Test_square_2;
+begin
+  Assert.AreEqual(2, Grains.Square(2));
+end;
+
+procedure TgrainsTests.Test_square_3;
+begin
+  Assert.AreEqual(3, Grains.Square(3));
+end;
+
+procedure TgrainsTests.Test_square_4;
+begin
+  Assert.AreEqual(8, Grains.Square(4));
+end;
+
+procedure TgrainsTests.Test_square_16;
+begin
+  Assert.AreEqual(32768, Grains.Square(16));
+end;
+
+procedure TgrainsTests.Test_square_32;
+begin
+  Assert.AreEqual(2147483648, Grains.Square(32));
+end;
+
+procedure TgrainsTests.Test_square_64;
+begin
+  Assert.AreEqual(9223372036854775808, Grains.Square(64));
+end;
+
+procedure TgrainsTests.Test_total_grains;
+begin
+  Assert.AreEqual(18446744073709551615, Grains.Total);
+end;
+
+procedure TgrainsTests.Square_0_raises_an_exception;
+begin
+
+end;
+
+procedure TgrainsTests.Negative_square_raises_an_exception;
+begin
+
+end;
+
+procedure TgrainsTests.Square_greater_than_64_raises_an_exception;
+begin
+
+end;
+
+procedure TgrainsTests.Test_total_grains;
+begin
+  Assert.AreEqual(18446744073709551615, Grains.Total);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(hpTests);
+end.


### PR DESCRIPTION
exercise based on C# example but updated to follow canonical-data.json for this exercise.